### PR TITLE
Astral Sorcery Fixes

### DIFF
--- a/config/astralsorcery.cfg
+++ b/config/astralsorcery.cfg
@@ -15,8 +15,8 @@ cape {
         # Defines the amount of health that is regenerated per cape-effect-cycle/tick [range: 0.0 ~ 4.0, default: 0.04]
         S:aevitasHealPerCycle=0.04
 
-        # Defines the chance that the aoe will search for a plant to turn into another plant. [range: 0.0 ~ 1.0, default: 0.2]
-        S:aevitasPlantTransformChance=0.2
+        # Defines the chance that the aoe will search for a plant to turn into another plant. [range: 0.0 ~ 1.0, default: 0.0]
+        S:aevitasPlantTransformChance=0.0
 
         # Defines the multiplier if the aoe will happen at all [range: 0.0 ~ 1.0, default: 1.0]
         S:aevitasPotency=1.0
@@ -56,7 +56,7 @@ cape {
 
     fornax {
         # If a player burns while wearing the cape, this toggles if blocks below him then melt (true) or not. (false) [default: true]
-        B:fornaxBurningMelt=true
+        B:fornaxBurningMelt=false
 
         # Sets the multiplier for how much damage you take from fire damage while wearing a fornax cape [range: 0.0 ~ 1.0, default: 0.4]
         S:fornaxFireDmgMultiplier=0.4
@@ -408,8 +408,8 @@ perks {
     }
 
     key_stone_enrichment {
-        # Sets the chance (Random.nextInt(chance) == 0) to try to see if a random stone next to the player should get turned into an ore; the lower the more likely [range: 2 ~ 4000000, default: 70]
-        I:Chance_To_CreateOre=70
+        # Sets the chance (Random.nextInt(chance) == 0) to try to see if a random stone next to the player should get turned into an ore; the lower the more likely [range: 2 ~ 4000000, default: 4000000]
+        I:Chance_To_CreateOre=4000000
 
         # Defines the radius where a random position to generate a ore at is searched [range: 1 ~ 35, default: 3]
         I:Effect_Radius=3
@@ -421,8 +421,8 @@ perks {
     }
 
     key_growables {
-        # Sets the chance (Random.nextInt(chance) == 0) to try to see if a random plant near the player gets bonemeal'd; the lower the more likely [range: 1 ~ 1000000, default: 3]
-        I:Growth_Chance=3
+        # Sets the chance (Random.nextInt(chance) == 0) to try to see if a random plant near the player gets bonemeal'd; the lower the more likely [range: 1 ~ 1000000, default: 1000000]
+        I:Growth_Chance=1000000
 
         # Defines the radius around which the perk effect should apply around the player [range: 1 ~ 16, default: 3]
         I:Radius=3
@@ -509,10 +509,6 @@ perks {
     key_void_trash {
         # The list of items to delete when dropped by a player with this perk. Damage/metadata value is optional and 'any' damage value is matched if omitted. Format: <modid>:<name>(:<metadata>) [default: [minecraft:stone:0], [minecraft:dirt], [minecraft:cobblestone], [minecraft:gravel]]
         S:DropList <
-            minecraft:stone:0
-            minecraft:dirt
-            minecraft:cobblestone
-            minecraft:gravel
          >
 
         # Chance that a voided drop will instead yield a valuable random ore out of the 'perk_void_trash_replacement' configured ore table. [range: 0.0 ~ 1.0, default: 2.0E-4]
@@ -611,8 +607,8 @@ ritual_effects {
     }
 
     evorsio {
-        # Set to false to disable this ConstellationEffect. [default: true]
-        B:evorsioEnabled=true
+        # Set to false to disable this ConstellationEffect. [default: false]
+        B:evorsioEnabled=false
 
         # Set the potency multiplier for this ritual effect. Will affect all ritual effects and their efficiency. [range: 0.01 ~ 100.0, default: 1.0]
         S:evorsioPotencyMultiplier=1.0
@@ -729,8 +725,8 @@ ritual_effects {
     }
 
     pelotrio {
-        # Set to false to disable this ConstellationEffect. [default: true]
-        B:pelotrioEnabled=true
+        # Set to false to disable this ConstellationEffect. [default: false]
+        B:pelotrioEnabled=false
 
         # Set the potency multiplier for this ritual effect. Will affect all ritual effects and their efficiency. [range: 0.01 ~ 100.0, default: 1.0]
         S:pelotrioPotencyMultiplier=1.0

--- a/scripts/MALFcraftScript.zs
+++ b/scripts/MALFcraftScript.zs
@@ -1,8 +1,9 @@
 import crafttweaker.item.IItemStack;
 import crafttweaker.oredict.IOreDict;
 import crafttweaker.oredict.IOreDictEntry;
-import mods.roots.Mortar;
+import mods.astralsorcery.Altar;
 import mods.tconstruct.Drying;
+import mods.roots.Mortar;
 
 recipes.removeShaped(<botania:laputashard>);
 recipes.removeShaped(<botania:terrapick>);
@@ -28,3 +29,5 @@ recipes.remove(<extrautils2:opinium:8>);
 val portal_core = <extrautils2:opinium:8>;
 recipes.addShaped("NewCore",portal_core, [[<arcanearchives:raw_quartz_cluster>,<thaumcraft:salis_mundus>,<totemic:eagle_drops>],
 [<naturesaura:effect_powder>,<waystones:warp_stone>,<astralsorcery:itemusabledust>],[<botania:manaresource:8>,<roots:infernal_bulb>,<tconstruct:nuggets:2>]]);
+
+Altar.removeAltarRecipe("astralsorcery:shaped/internal/altar/lens_grow");


### PR DESCRIPTION
Remove "Colored Lens (Growth)" item and "Spreading Growth" perk from Astral Sorcery
Disable Aecitas Cape Plant Transform
Disable Fornax Cape Melting
key_stone_enrichment set Chance_To_CreateOre=4000000 (disable)
key_void_trash Clear Droplist (disable)
Disable the following rituals: Evorsio, Fornax, Pelotrio